### PR TITLE
Updated compass version in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # Read about Gemfiles at http://bundler.io/v1.5/man/gemfile.5.html
 source 'https://rubygems.org'
 gem 'sass', '>= 3.4'
-gem 'compass', '>= 1.0.1'
+gem 'compass', '>= 1.0.3'
 gem 'sass-globbing', '>= 1.1.0'


### PR DESCRIPTION
Compass gem was not automatically updating to 1.0.3, so this message was coming up on compass watch/compile:

/home/user/.rvm/gems/ruby-2.2.1/gems/compass-core-1.0.1/lib/compass/core/caniuse.rb:72: warning: circular argument reference - browsers
